### PR TITLE
Moves `get_current_screen()` before `wp_count_posts()` in `Automattic\Jetpack\Forms\ContactForm\Admin\print_export_modal`

### DIFF
--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -109,13 +109,13 @@ class Admin {
 			return;
 		}
 
-		// if there aren't any feedbacks, bail out
-		if ( ! (int) wp_count_posts( 'feedback' )->publish ) {
+		$current_screen = get_current_screen();
+		if ( ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
 			return;
 		}
 
-		$current_screen = get_current_screen();
-		if ( ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
+		// if there aren't any feedbacks, bail out
+		if ( ! (int) wp_count_posts( 'feedback' )->publish ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #36228

## Proposed changes:
This PR moves the call to `get_current_screen()` before the call to `wp_count_posts() in `Automattic\Jetpack\Forms\ContactForm\Admin\print_export_modal` to prevent the query performed by `wp_count_posts()` from being run on every admin page. This was causing a slow query for us, as we have many `feedback` posts.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Enable the Jetpack plugin
2. Optionally, enable the [Query Monitor plugin](https://wordpress.org/plugins/query-monitor/) to easily view queries running on each page
3. Notice that the following query executes on every admin page:
```
SELECT post_status, COUNT( * ) AS num_posts
FROM wp_48_posts
WHERE post_type = 'feedback'
GROUP BY post_status
```
4. Optionally, create a large amount of feedback post types, and the Query Monitor plugin will flag this as "slow query"

